### PR TITLE
Add waveplot, spectrogram, melspectrogram, and chromogram generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ To change audio file type
 genreml process -fp "/Users/adamsrosales/Documents/audio-clips/fma_small/000" -af mp3
 ```
 
+To change export colot images and change image size to X in wide by Y in high
+```
+genreml process -fp "/Users/adamsrosales/Documents/audio-clips/fma_small/000" -cmap None -fw 15.0 -fh 5.0
+```
+
 # Using genreml as a Package in Python
 
 You can import genreml after a successful installation like any Python package
@@ -154,4 +159,17 @@ audio_files.extract_features("[YOUR_FILE_PATH]", output_to_file=False)
 Run feature extraction on a directory or filepath of your choice but export results to a destination filepath
 ```
 audio_files.extract_features("[YOUR_FILE_PATH]", destination_filepath="[YOUR_DESTINATION_PATH]")
+```
+
+Change color of images generated
+```
+audio_files.extract_features("[YOUR_FILE_PATH]", destination_filepath="[YOUR_DESTINATION_PATH]", cmap=None)
+```
+
+Change size of images generated to 15 by 5 inches
+```
+audio_files.extract_features(
+    "[YOUR_FILE_PATH]", destination_filepath="[YOUR_DESTINATION_PATH]",
+    figure_width=15, figure_height=5
+)
 ```

--- a/aws_infrastructure/genreml-cloudformation-template.yml
+++ b/aws_infrastructure/genreml-cloudformation-template.yml
@@ -1,0 +1,28 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Defines AWS infrastructure used for genreml (OSU CS467 capstone class)"
+Resources:
+  # Bucket used to host resources used for the production site
+  GenremlProdBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: "genreml-cft-model-hosting"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: 'true'
+        BlockPublicPolicy: 'true'
+        IgnorePublicAcls: 'true'
+        RestrictPublicBuckets: 'true'
+  # Bucket used to ingest dev model resources
+  GenremlIngestionBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: "genreml-cft-model-ingestion"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: 'true'
+        BlockPublicPolicy: 'true'
+        IgnorePublicAcls: 'true'
+        RestrictPublicBuckets: 'true'

--- a/genreml/model/__main__.py
+++ b/genreml/model/__main__.py
@@ -24,6 +24,14 @@ def parse_args():
     parser.add_argument(
         '-af', '--audio_format', default=config.AudioConfig.AUDIO_FORMAT, help='the format of the audio to process')
     parser.add_argument(
+        '-cmap', '--cmap', default=config.DisplayConfig.CMAP,
+        help='matplotlib colormap https://matplotlib.org/3.1.0/tutorials/colors/colormaps.html ("None" = default color)'
+    )
+    parser.add_argument(
+        '-fw', '--figure_width', default=config.DisplayConfig.FIGSIZE_WIDTH, help='the width of the figures created')
+    parser.add_argument(
+        '-fh', '--figure_height', default=config.DisplayConfig.FIGSIZE_HEIGHT, help='the height of the figures created')
+    parser.add_argument(
         '-cf', '--checkpoint_frequency', default=config.AudioConfig.CHECKPOINT_FREQUENCY,
         help='how many tracks to process before saving features'
     )
@@ -61,6 +69,9 @@ def run(args):
     elif args.operation == 'process':
         processor = audio.AudioFiles()
         features_to_exclude = string_parsing.str_to_collection(args.exclude_features, set)
+        cmap = args.cmap
+        if cmap.lower() == "none":
+            cmap = None
         # Define the destination path
         if not args.destination_path and not args.example:
             # Use same path as input file_path if a -dp is not provided
@@ -70,10 +81,15 @@ def run(args):
             feature_destination_path = args.destination_path
         # Run the feature extraction
         if args.example:
-            processor.extract_sample_fma_features(destination_filepath=feature_destination_path)
+            processor.extract_sample_fma_features(
+                destination_filepath=feature_destination_path, audio_format=args.audio_format)
         else:
             processor.extract_features(args.file_path, feature_destination_path,
-                                       features_to_exclude=features_to_exclude)
+                                       features_to_exclude=features_to_exclude,
+                                       cmap=cmap, figure_width=float(args.figure_width),
+                                       figure_height=float(args.figure_height),
+                                       audio_format=args.audio_format
+                                       )
 
 
 def main():

--- a/genreml/model/processing/audio.py
+++ b/genreml/model/processing/audio.py
@@ -9,14 +9,14 @@ import pandas as pd
 import glob
 import json
 
-from genreml.model.processing.audio_features import SpectrogramGenerator, LibrosaFeatureGenerator
-from genreml.model.processing.config import AudioConfig
+from genreml.model.processing.audio_features import SpectrogramGenerator, LibrosaFeatureGenerator, WavePlotGenerator
+from genreml.model.processing.config import AudioConfig, DisplayConfig
 from genreml.model.utils import file_handling
 
 
 class AudioFile(object):
 
-    def __init__(self, file_path, audio_signal, sample_rate):
+    def __init__(self, file_path: str, audio_signal, sample_rate):
         """ Instantiates an AudioFile object that collects various attributes related to an audio file and exposes
         methods to extract features from that file
         """
@@ -26,38 +26,113 @@ class AudioFile(object):
         self.audio_signal = audio_signal
         self.sample_rate = sample_rate
 
-    def to_spectrogram(self, destination_filepath, spec_generator=None):
-        """ Extract spectrogram from the audio data and save to the destination path
+    def _get_figure_filepath(self, destination_filepath: str, figure_type: str) -> str:
+        return "{0}{1}_{2}".format(
+            destination_filepath, figure_type, self.file_name.replace(self.audio_type, ""))
+
+    def _save_figure(self, generator, figure, destination_filepath: str, figure_type: str) -> str:
+        path = self._get_figure_filepath(destination_filepath, figure_type)
+        logging.info("saving {0} to {1}".format(figure_type, path))
+        figure.savefig(path)
+        generator.close_img(figure)
+        return path + ".png"
+
+    def to_spectrogram(
+            self, destination_filepath: str, spec_generator=None,
+            spectrogram_type: str = "spectrogram", cmap: str = None,
+            figure_width: float = DisplayConfig.FIGSIZE_WIDTH, figure_height: float = DisplayConfig.FIGSIZE_HEIGHT):
+        """ Extract spectrogram from the audio data and saves the resulting image to the destination path
 
         :param string destination_filepath: the file path to save the spectrogram to
         :param model.processing.audio_features.SpectrogramGenerator spec_generator: option. spectrogram generator to use
+        :param spectrogram_type: the type of spectrogram to generate
+        :param cmap: https://matplotlib.org/3.3.2/api/_as_gen/matplotlib.axes.Axes.imshow.html
+        :param figure_width: the spectrogram width in inches
+        :param figure_height: the spectrogram height in inches
+        :returns the full path location of the saved melspetrogram image
         """
-        logging.info("generating spectrogram for {0}".format(self.file_name))
+        logging.info("generating {0} for {1}".format(spectrogram_type, self.file_name))
         if not spec_generator:
-            spec_generator = SpectrogramGenerator(self.audio_signal, self.sample_rate)
-        full_path = "{0}spectrogram_{1}".format(
-            destination_filepath, self.file_name.replace(self.audio_type, ""))
-        spectrogram = spec_generator.generate()
-        spectrogram.savefig(full_path)
-        logging.info("saving spectrogram to {0}".format(full_path))
-        spec_generator.close_spectrogram(spectrogram)
-        return full_path + ".png"
+            spec_generator = SpectrogramGenerator(
+                self.audio_signal, self.sample_rate, spectrogram_type=spectrogram_type)
+        spectrogram = spec_generator.generate(cmap=cmap, figure_width=figure_width, figure_height=figure_height)
+        full_path = self._save_figure(spec_generator, spectrogram, destination_filepath, spectrogram_type)
+        return full_path
+
+    def to_melspectrogram(self, destination_filepath: str, spec_generator=None, cmap: str = None,
+                          figure_width: float = DisplayConfig.FIGSIZE_WIDTH,
+                          figure_height: float = DisplayConfig.FIGSIZE_HEIGHT):
+        """ Extract melspectrogram from the audio data and saves the resulting image to the destination path
+
+        :param string destination_filepath: the file path to save the melspectrogram to
+        :param model.processing.audio_features.SpectrogramGenerator spec_generator: option. spectrogram generator to use
+        :param cmap: https://matplotlib.org/3.3.2/api/_as_gen/matplotlib.axes.Axes.imshow.html
+        :param figure_width: the melspectrogram width in inches
+        :param figure_height: the melspectrogram height in inches
+        :returns the full path location of the saved melspetrogram image
+        """
+        return self.to_spectrogram(
+            destination_filepath, spec_generator, spectrogram_type="melspectrogram", cmap=cmap,
+            figure_width=figure_width, figure_height=figure_height)
+
+    def to_chromagram(self, destination_filepath: str, spec_generator=None, cmap: str = None,
+                      figure_width: float = DisplayConfig.FIGSIZE_WIDTH,
+                      figure_height: float = DisplayConfig.FIGSIZE_HEIGHT
+                      ):
+        """ Extract chromagram from the audio data and saves the resulting image to the destination path
+
+        :param string destination_filepath: the file path to save the chromagram to
+        :param model.processing.audio_features.SpectrogramGenerator spec_generator: option. spectrogram generator to use
+        :param cmap: https://matplotlib.org/3.3.2/api/_as_gen/matplotlib.axes.Axes.imshow.html
+        :param figure_width: the chromogram width in inches
+        :param figure_height: the chromogram height in inches
+        :returns the full path location of the saved chromagram image
+        """
+        return self.to_spectrogram(
+            destination_filepath, spec_generator, spectrogram_type="chromagram", cmap=cmap,
+            figure_width=figure_width, figure_height=figure_height
+        )
+
+    def to_waveplot(self, destination_filepath: str, waveplot_generator=None, cmap: str = None,
+                    figure_width: float = DisplayConfig.FIGSIZE_WIDTH,
+                    figure_height: float = DisplayConfig.FIGSIZE_HEIGHT
+                    ):
+        logging.info("generating waveplot for {0}".format(self.file_name))
+        if not waveplot_generator:
+            waveplot_generator = WavePlotGenerator(self.audio_signal, self.sample_rate)
+        waveplot = waveplot_generator.generate(cmap=cmap, figure_width=figure_width, figure_height=figure_height)
+        full_path = self._save_figure(waveplot_generator, waveplot, destination_filepath, "waveplot")
+        return full_path
+
+    def extract_visual_features(
+            self, destination_filepath: str, cmap: str = DisplayConfig.CMAP, exclusion_set: set = None,
+            figure_width: float = DisplayConfig.FIGSIZE_WIDTH, figure_height: float = DisplayConfig.FIGSIZE_HEIGHT
+    ):
+        visual_features_to_method_map = {
+            "spectrogram": self.to_spectrogram,
+            "melspectrogram": self.to_melspectrogram,
+            "chromagram": self.to_chromagram,
+            "waveplot": self.to_waveplot
+        }
+        for feature_name, feature_method in visual_features_to_method_map.items():
+            if feature_name not in exclusion_set:
+                feature_method(destination_filepath, cmap=cmap, figure_width=figure_width, figure_height=figure_height)
 
     def extract_features(self,
                          aggregate_features: bool = True,
-                         exclude_features: set = None,
+                         exclusion_set: set = None,
                          feature_generator: LibrosaFeatureGenerator = None):
         """ Extract librosa features from the audio data
 
         :param aggregate_features - whether to aggregate the features extracted or not
-        :param exclude_features - an optional set of feature names to exclude from the feature generation
+        :param exclusion_set - an optional set of feature names to exclude from the feature generation
         :param feature_generator - an optional generator to use for generating the features
         :returns a dictionary containing the feature names as keys and the data as values
         """
         logging.info("generating librosa features for {0}".format(self.file_name))
         if not feature_generator:
             feature_generator = LibrosaFeatureGenerator(
-                self.audio_signal, self.sample_rate, aggregate_features, exclude_features)
+                self.audio_signal, self.sample_rate, aggregate_features, exclusion_set)
         # Extract features
         features = feature_generator.generate()
         # Append the identifiers for the current audio file to the feature object
@@ -100,7 +175,10 @@ class AudioFiles(dict):
             self.bad_files_loaded[file_location] = e
 
     def _run_feature_extraction(
-            self, audio_file, file_location, destination_filepath=None, features_to_exclude=None, output_to_file=True):
+            self, audio_file, file_location, destination_filepath=None,
+            features_to_exclude=None, output_to_file=True, cmap=DisplayConfig.CMAP,
+            figure_width: float = DisplayConfig.FIGSIZE_WIDTH, figure_height: float = DisplayConfig.FIGSIZE_HEIGHT
+    ):
         """ Extracts features from a given AudioFile object representing a file in the given file_location and
         saves the features to destination_filepath
 
@@ -113,9 +191,13 @@ class AudioFiles(dict):
         if not features_to_exclude:
             features_to_exclude = set()
         try:
-            if output_to_file and 'spectrogram' not in features_to_exclude:
-                audio_file.to_spectrogram(destination_filepath.replace(" ", ""))
-            self.features.append(audio_file.extract_features(exclude_features=features_to_exclude))
+            if output_to_file:
+                destination_filepath = destination_filepath.replace(" ", "")
+                audio_file.extract_visual_features(
+                    destination_filepath, cmap=cmap, exclusion_set=features_to_exclude,
+                    figure_width=figure_width, figure_height=figure_height
+                )
+            self.features.append(audio_file.extract_features(exclusion_set=features_to_exclude))
         except Exception as e:
             logging.warning("failed to extract features from {0}".format(file_location))
             logging.warning(e)
@@ -165,7 +247,10 @@ class AudioFiles(dict):
 
     def extract_features(self,
                          file_locations, destination_filepath=None, features_to_exclude=None,
-                         load=True, audio_format=AudioConfig.AUDIO_FORMAT, output_to_file=True):
+                         load=True, audio_format=AudioConfig.AUDIO_FORMAT, output_to_file=True, cmap=DisplayConfig.CMAP,
+                         figure_width: float = DisplayConfig.FIGSIZE_WIDTH,
+                         figure_height: float = DisplayConfig.FIGSIZE_HEIGHT
+                         ):
         """ Iterates over all of the files in the file_locations, loads them in to extract audio data, and
         generates features
 
@@ -175,6 +260,9 @@ class AudioFiles(dict):
         :param bool load: whether to load the files before extracting the features
         :param string audio_format: the format of the audio files in directory (wav, mp3, etc.)
         :param bool output_to_file: whether to output results to a particular file or not
+        :param cmap: https://matplotlib.org/3.3.2/api/_as_gen/matplotlib.axes.Axes.imshow.html
+        :param figure_width: the visual feature figure width in inches
+        :param figure_height: the visual feature figure height in inches
         """
         if output_to_file and not destination_filepath:
             raise ValueError("You must provide a valid destination_filepath to output results")
@@ -189,7 +277,10 @@ class AudioFiles(dict):
             if load:
                 self._load_file(file_locations)
             self._run_feature_extraction(
-                self[file_locations], file_locations, destination_filepath, features_to_exclude, output_to_file)
+                self[file_locations], file_locations, destination_filepath, features_to_exclude, output_to_file,
+                cmap=cmap, figure_width=figure_width, figure_height=figure_height
+
+            )
         # Load in all applicable files if the given location is a directory
         elif os.path.isdir(file_locations):
             logging.info("extracting features from {0} audio files in directory {1}".format(
@@ -204,7 +295,9 @@ class AudioFiles(dict):
                     self._load_file(file)
                 try:
                     self._run_feature_extraction(
-                        self[file], file, destination_filepath, features_to_exclude, output_to_file)
+                        self[file], file, destination_filepath, features_to_exclude, output_to_file,
+                        cmap=cmap, figure_width=figure_width, figure_height=figure_height
+                    )
                     # Checkpoint features every AudioConfig.CHECKPOINT_FREQUENCY tracks
                     if (idx + 1) % AudioConfig.CHECKPOINT_FREQUENCY == 0 and output_to_file:
                         self._checkpoint_feature_extraction(destination_filepath)
@@ -232,11 +325,14 @@ class AudioFiles(dict):
         with open(filepath, 'w') as outfile:
             json.dump(self, outfile)
 
-    def extract_sample_fma_features(self, destination_filepath=None, output_to_file=True):
+    def extract_sample_fma_features(self, destination_filepath=None, output_to_file=True,
+                                    audio_format=AudioConfig.AUDIO_FORMAT):
         """ Retrieves audio features from sample FMA audio files packaged with the application in genreml/fma_data
 
         :param str destination_filepath: the optional path to save features to as part of regular feature extraction
         :param bool output_to_file: whether to save the features in the given destination_filepath or not
+        :param string audio_format: the format of the audio files in directory (wav, mp3, etc.)
         """
         path = pkg_resources.resource_filename('genreml', 'fma_data/')
-        self.extract_features(path, destination_filepath=destination_filepath, output_to_file=output_to_file)
+        self.extract_features(
+            path, destination_filepath=destination_filepath, output_to_file=output_to_file, audio_format=audio_format)

--- a/genreml/model/processing/config.py
+++ b/genreml/model/processing/config.py
@@ -11,6 +11,15 @@ class AudioConfig:
     CHECKPOINT_FREQUENCY = 10
 
 
+class DisplayConfig:
+    # What cmap to use when saving visual features
+    # Refer to https://matplotlib.org/3.3.2/api/_as_gen/matplotlib.axes.Axes.imshow.html
+    CMAP = "Greys"
+    # Defines the size of the figures created by display
+    FIGSIZE_WIDTH = 10
+    FIGSIZE_HEIGHT = 10
+
+
 class YoutubeExtractionConfig:
     # URL to make request to for audio results
     SEARCH_URL = 'https://www.youtube.com/results'
@@ -41,3 +50,5 @@ class FeatureExtractorConfig:
     NUMBER_OF_MFCC_COLS = 20
     # How to aggregate the features
     FEATURE_AGGREGATION = ['mean', 'min', 'max', 'std']
+    N_FFT = 2048
+    HOP_LENGTH = 1024

--- a/genreml/model/processing/display.py
+++ b/genreml/model/processing/display.py
@@ -1,0 +1,57 @@
+# Name: display.py
+# Description: defines common display functionality for matplot graphics
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from genreml.model.processing.config import DisplayConfig
+
+
+class VisualDataMixin(object):
+    """ Defines common functionality for visualization of features """
+
+    @staticmethod
+    def normalize(visual_data: np.array) -> np.array:
+        return 255 * ((visual_data - visual_data.min()) /
+                      (visual_data.max() - visual_data.min()))
+
+    @staticmethod
+    def convert_pixels_to_8_bits(visual_data: np.array) -> np.array:
+        return visual_data.astype(np.uint8)
+
+    @staticmethod
+    def flip_and_invert(visual_data: np.array) -> np.array:
+        flipped_img = np.flip(visual_data, axis=0)
+        return 255 - flipped_img
+
+    @staticmethod
+    def create_display_figure(frameon: bool = False, display_axes: bool = False,
+                              x_axis_name: str = None, y_axis_name: str = None,
+                              figure_width: float = DisplayConfig.FIGSIZE_WIDTH,
+                              figure_height: float = DisplayConfig.FIGSIZE_HEIGHT) -> tuple:
+        print("Creating display figure with {0},{1}".format(figure_width, figure_height))
+        fig = plt.figure(frameon=frameon, figsize=(figure_width, figure_height))
+        ax = plt.Axes(fig, [0., 0., 1., 1.])
+        if not display_axes:
+            ax.set_axis_off()
+        else:
+            ax.set(xlabel=x_axis_name, ylabel=y_axis_name)
+        fig.add_axes(ax)
+        return fig, ax
+
+    @staticmethod
+    def display_data(
+            visual_data: np.array, frameon: bool = False, cmap: str = DisplayConfig.CMAP,
+            display_axes: bool = False, x_axis_name: str = None, y_axis_name: str = None,
+            figure_width: float = DisplayConfig.FIGSIZE_WIDTH, figure_height: float = DisplayConfig.FIGSIZE_HEIGHT
+    ) -> plt.figure:
+        """ Displays the given data in a matplotlib figure and returns the figure object """
+        fig, ax = VisualDataMixin.create_display_figure(
+            frameon, display_axes, x_axis_name, y_axis_name, figure_width=figure_width, figure_height=figure_height)
+        ax.imshow(visual_data, aspect='auto', cmap=cmap)
+        return fig
+
+    @staticmethod
+    def close_img(fig: plt.figure) -> None:
+        """ Closes a matplotlib figure """
+        plt.close(fig)

--- a/test/test_feature_extraction.py
+++ b/test/test_feature_extraction.py
@@ -1,39 +1,54 @@
-import pkg_resources
+import glob
 import os
+import pkg_resources
 
 from genreml.model.processing.audio import AudioFiles
-
-AUDIO_FILES_PROCESSOR = AudioFiles()
 
 
 def test_extract_features():
     """ Tests genreml.model.processing.audio.AudioFiles.extract_features method """
+    audio_files_processor = AudioFiles()
     sample_data_path = pkg_resources.resource_filename('genreml', 'fma_data/')
-    AUDIO_FILES_PROCESSOR.extract_sample_fma_features(output_to_file=False)
+    audio_files_processor.extract_sample_fma_features(destination_filepath=os.getcwd())
     files = os.listdir(sample_data_path)
     file_count = len(files)
-    assert len(AUDIO_FILES_PROCESSOR.features) == file_count
+    assert len(audio_files_processor.features_saved) == file_count
+    expected_files = [
+        "./features/waveplot*", "./features/melspectrogram*", "./features/chromagram*", "./features/spectrogram*"
+    ]
+    # There should be as many of the file types above as input file count
+    for expected_file in expected_files:
+        assert len(glob.glob(expected_file)) == file_count
 
 
 def test_to_df():
     """ Tests genreml.model.processing.audio.AudioFiles.to_df method """
-    df, record_count = AUDIO_FILES_PROCESSOR.to_df()
+    audio_files_processor = AudioFiles()
+    features = [{"feature_a": 1, "feature_b": 2}, {"feature_a": 2, "feature_b": 3}]
+    audio_files_processor.features = features
+    df, record_count = audio_files_processor.to_df()
     assert df.shape[0] == record_count \
-        and record_count == len(AUDIO_FILES_PROCESSOR.features)
-    assert len(df.columns) == len(AUDIO_FILES_PROCESSOR.features[0])
+        and record_count == len(audio_files_processor.features)
+    assert len(df.columns) == len(audio_files_processor.features[0])
 
 
 def test_to_csv():
     """ Tests genreml.model.processing.audio.AudioFiles.to_csv method """
-    df, filepath = AUDIO_FILES_PROCESSOR.to_csv("")
-    assert df.shape[0] == len(AUDIO_FILES_PROCESSOR.features)
+    audio_files_processor = AudioFiles()
+    features = {"feature_a": 1, "feature_b": 2}, {"feature_a": 2, "feature_b": 3}
+    audio_files_processor.features = features
+    df, filepath = audio_files_processor.to_csv("")
+    assert df.shape[0] == len(audio_files_processor.features)
     assert os.path.isfile(filepath)
     os.remove(filepath)
 
 
 def test_feature_checkpointing():
     """ Tests genreml.model.processing.audio.AudioFiles._checkpoint_feature_extraction method """
-    previous_feature_length = len(AUDIO_FILES_PROCESSOR.features)
-    AUDIO_FILES_PROCESSOR._checkpoint_feature_extraction("")
-    assert len(AUDIO_FILES_PROCESSOR.features_saved) == previous_feature_length
-    assert len(AUDIO_FILES_PROCESSOR.features) == 0
+    audio_files_processor = AudioFiles()
+    features = {"feature_a": 1, "feature_b": 2}, {"feature_a": 2, "feature_b": 3}
+    audio_files_processor.features = features
+    previous_feature_length = len(features)
+    audio_files_processor._checkpoint_feature_extraction("")
+    assert len(audio_files_processor.features_saved) == previous_feature_length
+    assert len(audio_files_processor.features) == 0

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,4 +5,4 @@
 { # If python fails, try with python3
   pip3 uninstall genreml
 }
-rm -rf ./.eggs ./build ./dist ./.pytest_cache ./.coverage ./test_dir*
+rm -rf ./.eggs ./build ./dist ./.pytest_cache ./.coverage ./test_dir* feature_data_* features *.egg*


### PR DESCRIPTION
## Notes
- Adding additional visual feature generation: chromagrams, spectrograms, melspectrograms, and wave plots
- Adding initial AWS CloudFormation template
- Adding option to display graphics in a custom colormap (grayscale is default)
- Adding option to change the size of the graphics
- Building upon initial feature extraction unit tests

![image](https://user-images.githubusercontent.com/55367120/98621271-bc669400-22bb-11eb-9626-4945ffe2d326.png)
![image](https://user-images.githubusercontent.com/55367120/98621275-bec8ee00-22bb-11eb-8f2b-72535df63a24.png)
![image](https://user-images.githubusercontent.com/55367120/98621285-c2f50b80-22bb-11eb-8895-4c6fbc9b13b8.png)
![image](https://user-images.githubusercontent.com/55367120/98621290-c4becf00-22bb-11eb-9883-6652de0735f6.png)


## Testing 
unit tests and ran locally