### PR TITLE
Fixing feature_name naming in feature extraction

### DIFF
--- a/genreml/model/processing/audio_features.py
+++ b/genreml/model/processing/audio_features.py
@@ -205,16 +205,16 @@ class LibrosaFeatureGenerator(FeatureGenerator):
         aggregated_features = {}
         aggregation_functions = {'mean': np.mean, 'min': np.min, 'max': np.max, 'std': np.std}
         feature_names = []
-        for feature_name, data in feature_dict.items():
+        for feature, data in feature_dict.items():
             # Aggregate the feature data and store the aggregations in the aggregated features dictionary
-            if feature_name != 'mfcc':
+            if feature != 'mfcc':
                 for aggregation in self.aggregations:
                     if aggregation not in aggregation_functions:
                         raise ValueError(
                             "aggregation {0} is not associated with a valid aggregation function".format(aggregation))
                     # Apply the aggregation result and store it
                     aggregation_function = aggregation_functions[aggregation]
-                    feature_name = '{0}-{1}'.format(feature_name, aggregation)
+                    feature_name = '{0}-{1}'.format(feature, aggregation)
                     aggregated_features[feature_name] = aggregation_function(data)
                     feature_names.append(feature_name)
             else:

--- a/genreml/model/processing/audio_features.py
+++ b/genreml/model/processing/audio_features.py
@@ -205,7 +205,7 @@ class LibrosaFeatureGenerator(FeatureGenerator):
         aggregated_features = {}
         aggregation_functions = {'mean': np.mean, 'min': np.min, 'max': np.max, 'std': np.std}
         feature_names = []
-        for feature_name, data in feature_dict.items():
+        for feature, data in feature_dict.items():
             # Aggregate the feature data and store the aggregations in the aggregated features dictionary
             if feature_name != 'mfcc':
                 for aggregation in self.aggregations:
@@ -214,7 +214,7 @@ class LibrosaFeatureGenerator(FeatureGenerator):
                             "aggregation {0} is not associated with a valid aggregation function".format(aggregation))
                     # Apply the aggregation result and store it
                     aggregation_function = aggregation_functions[aggregation]
-                    feature_name = '{0}-{1}'.format(feature_name, aggregation)
+                    feature_name = '{0}-{1}'.format(feature, aggregation)
                     aggregated_features[feature_name] = aggregation_function(data)
                     feature_names.append(feature_name)
             else:


### PR DESCRIPTION
The naming of the feature_name variable in the iteration over the features in feature extraction is unclear and introduces a bug. Changing it so the names don't conflict.